### PR TITLE
Fixed syntax in case of item without applications

### DIFF
--- a/src/history_influxdb.c
+++ b/src/history_influxdb.c
@@ -254,7 +254,7 @@ char *itemid_to_influx_data(zbx_uint64_t itemid)
 							// "i.key_"
 							// "), ' ', '\\ '), ',', '\\,') ||"
 
-							"',applications=' || coalesce(replace(replace(("
+							"coalesce(',applications=' || replace(replace(("
 							"select string_agg(a.name, '|') "
 							"from applications a "
 							"inner join items_applications ia on ia.applicationid = a.applicationid "


### PR DESCRIPTION
Idea is to exclude `applications` tag from line protocol altogether if the item has no applications. This should resolve #1.